### PR TITLE
Fix update of Facebook follower count

### DIFF
--- a/LIESMICH.md
+++ b/LIESMICH.md
@@ -1,0 +1,31 @@
+﻿![Screenshot](./images/screenshot.png)
+
+[README in English](./README.md)
+
+# [kirchen-im-web.de](https://kirchen-im-web.de/de/) - Verzeichnis kirchlicher Web- und Social-Media-Auftritte
+
+Wir wollen zeigen, dass viele Kirchengemeinden, Landeskirchen und Bistümer auch im Web 
+    gute Öffentlichtkeitsarbeit machen und stellen diese mit ihren Web- und Social-Media-Auftritten 
+    [in einer Karte](https://kirchen-im-web.de/de/karte/) und 
+    [tabellarisch](https://kirchen-im-web.de/de/suche/) dar.
+kirchen-im-web.de vergleicht auch die Follower-Zahlen der
+    [Social-Media-Auftritte](https://kirchen-im-web.de/de/vergleich/).
+
+Unser Projekt ist überkonfessionell, d. h. egal ob evangelisch, katholisch oder freikirchlich - alle können mitmachen. 
+Sie können Ihre Gemeinde einfach über unser 
+    [Formular](https://kirchen-im-web.de/de/eintragen/) hinzufügen.
+
+Die aktuelle Entwicklungsversion gibt es unter 
+    [test.kirchen-im-web.de](https://test.kirchen-im-web.de/de/).
+
+## Funktionen
+* [Karte](https://kirchen-im-web.de/de/karte/)
+    mit allen Gemeinden, die nach Konfession und Netzwerk gefiltert werden kann
+* [Tabelle](https://kirchen-im-web.de/de/suche/)
+    mit Filter nach Name, PLZ, Stadt, Land, Konfession, Gemeindetyp, Netzwerk
+* [Detailseite](https://kirchen-im-web.de/de/details/1/)
+    für jede Gemeinde, die alle Web- und Social-Media-Auftritte, eine Karte und die Hierarchie anzeigt
+* Formular zum [Hinzufügen neuer Gemeinden](https://kirchen-im-web.de/de/eintragen/)
+* [Statistik](https://kirchen-im-web.de/de/statistik/)
+    und herunterladbare [offene Daten](https://kirchen-im-web.de/de/daten/)
+* verfügbar in Deutsch und Englisch

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ﻿![Screenshot](./images/screenshot.png)
 
+[README in Deutsch](./LIESMICH.md)
+
 # [kirchen-im-web.de](https://kirchen-im-web.de/en/) - Directory of Churchy Websites and Social Network Pages 
 
 We want to show that many parishes, regional churches and dioceses
@@ -26,6 +28,15 @@ The latest development version is online at [test.kirchen-im-web.de](https://tes
 * [statistics](https://kirchen-im-web.de/en/statistics/)
     and downloadable [open data](https://kirchen-im-web.de/en/data/)
 * available in English and German
+
+## Link check and follower update
+The script `cron.php`
+- checks whether the listed websites are still online
+- and updates the follower count of the listed social media accounts.
+    Non-public pages can be excluded via `followerStatus = 2`.
+
+`followerStatus = 0` means that the last follower update failed.
+
 
 ## API Documentation
 
@@ -133,32 +144,3 @@ To run all checks, use `composer cs`.
     - the files `.htacess`, `*.png`, `browserconfig.xml`, `favicon.ico`
         `config.php`, `cron.php`, `index.php` and `manifest.json`.
 - Create empty directories `cache` and `data`.
-
-
-# [kirchen-im-web.de](https://kirchen-im-web.de/de/) - Verzeichnis kirchlicher Web- und Social-Media-Auftritte
-
-Wir wollen zeigen, dass viele Kirchengemeinden, Landeskirchen und Bistümer auch im Web 
-    gute Öffentlichtkeitsarbeit machen und stellen diese mit ihren Web- und Social-Media-Auftritten 
-    [in einer Karte](https://kirchen-im-web.de/de/karte/) und 
-    [tabellarisch](https://kirchen-im-web.de/de/suche/) dar.
-kirchen-im-web.de vergleicht auch die Follower-Zahlen der
-    [Social-Media-Auftritte](https://kirchen-im-web.de/de/vergleich/).
-
-Unser Projekt ist überkonfessionell, d. h. egal ob evangelisch, katholisch oder freikirchlich - alle können mitmachen. 
-Sie können Ihre Gemeinde einfach über unser 
-    [Formular](https://kirchen-im-web.de/de/eintragen/) hinzufügen.
-
-Die aktuelle Entwicklungsversion gibt es unter 
-    [test.kirchen-im-web.de](https://test.kirchen-im-web.de/de/).
-
-## Funktionen
-* [Karte](https://kirchen-im-web.de/de/karte/)
-    mit allen Gemeinden, die nach Konfession und Netzwerk gefiltert werden kann
-* [Tabelle](https://kirchen-im-web.de/de/suche/)
-    mit Filter nach Name, PLZ, Stadt, Land, Konfession, Gemeindetyp, Netzwerk
-* [Detailseite](https://kirchen-im-web.de/de/details/1/)
-    für jede Gemeinde, die alle Web- und Social-Media-Auftritte, eine Karte und die Hierarchie anzeigt
-* Formular zum [Hinzufügen neuer Gemeinden](https://kirchen-im-web.de/de/eintragen/)
-* [Statistik](https://kirchen-im-web.de/de/statistik/)
-    und herunterladbare [offene Daten](https://kirchen-im-web.de/de/daten/)
-* verfügbar in Deutsch und Englisch

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,10 @@
   "require": {
     "php": "^7.1",
     "ext-curl": "*",
+    "ext-dom": "*",
     "ext-gettext": "*",
     "ext-json": "*",
+    "ext-libxml": "*",
     "ext-pdo": "*",
     "j7mbo/twitter-api-php": "^1.0",
     "opencage/geocode": "^2.1",

--- a/cron.php
+++ b/cron.php
@@ -13,5 +13,6 @@ $l = new LinkCheckUpdater();
 $l->check();
 
 // Get follower data.
+$s = new SocialMediaUpdater();
 header('Content-Type: application/json;charset=utf-8');
-echo json_encode(SocialMediaUpdater::getInstance()->cron());
+echo json_encode($s->cron());

--- a/cron.php
+++ b/cron.php
@@ -1,4 +1,5 @@
 <?php
+
 use KirchenImWeb\Helpers\Exporter;
 use KirchenImWeb\Updaters\LinkCheckUpdater;
 use KirchenImWeb\Updaters\SocialMediaUpdater;

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 use KirchenImWeb\Controllers\APIController;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,7 +8,7 @@
     <arg name="colors"/>
 
     <!-- inherit rules from: -->
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
     <!-- Paths to check -->

--- a/src/Controllers/APIController.php
+++ b/src/Controllers/APIController.php
@@ -32,17 +32,17 @@ class APIController
         return $response->withJson(Exporter::getInstance()->removeNullValues($entries));
     }
 
-    public function church(Request $request, Response $response, array $args)
+    public function church(Request $request, Response $response, array $args): Response
     {
         $entry = Database::getInstance()->getEntry($args['id']);
         if ($entry) {
             return $response->withJson(Exporter::getInstance()->removeNullValues($entry));
-        } else {
-            return $response->withStatus(404);
         }
+
+        return $response->withStatus(404);
     }
 
-    public function children(Request $request, Response $response, array $args)
+    public function children(Request $request, Response $response, array $args): Response
     {
         $entry = Database::getInstance()->getEntry($args['id']);
         if ($entry) {
@@ -54,8 +54,8 @@ class APIController
                 Configuration::getInstance()->websites
             );
             return $response->withJson(Exporter::getInstance()->removeNullValues($children));
-        } else {
-            return $response->withStatus(404);
         }
+
+        return $response->withStatus(404);
     }
 }

--- a/src/Controllers/APIController.php
+++ b/src/Controllers/APIController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace KirchenImWeb\Controllers;
 
 use KirchenImWeb\Helpers\Configuration;

--- a/src/Controllers/FileController.php
+++ b/src/Controllers/FileController.php
@@ -20,14 +20,14 @@ class FileController extends TwigController
         parent::__construct($container);
     }
 
-    public function robots(Request $request, Response $response, array $args)
+    public function robots(Request $request, Response $response, array $args): Response
     {
         return $this->twig->render($response, 'files/robots.txt.twig', [
             'production' => PRODUCTION
         ])->withHeader('Content-Type', 'text/plain; charset=UTF-8');
     }
 
-    public function sitemap(Request $request, Response $response, array $args)
+    public function sitemap(Request $request, Response $response, array $args): Response
     {
         return $this->twig->render($response, 'files/sitemap.xml.twig', [
             'churches' => Database::getInstance()->getAllChurchesWithLastUpdate()

--- a/src/Controllers/PageController.php
+++ b/src/Controllers/PageController.php
@@ -44,7 +44,7 @@ class PageController extends TwigController
         ]);
     }
 
-    public function search(Request $request, Response $response, array $args)
+    public function search(Request $request, Response $response, array $args): Response
     {
         $pc = ParameterChecker::getInstance();
         $filters = $pc->extractFilterParameters($request);
@@ -61,12 +61,12 @@ class PageController extends TwigController
         ]);
     }
 
-    public function comparison(Request $request, Response $response, array $args)
+    public function comparison(Request $request, Response $response, array $args): Response
     {
         $pc = ParameterChecker::getInstance();
         $filters = $pc->extractFilterParameters($request);
         $websites = Configuration::getInstance()->networksToCompare;
-        $this->twig->render($response, 'pages/table.html.twig', [
+        return $this->twig->render($response, 'pages/table.html.twig', [
             'title' => _('Vergleich kirchlicher Social-Media-Auftritte'),
             'headline' => _('Vergleich kirchlicher Social-Media-Auftritte'),
             // phpcs:ignore Generic.Files.LineLength.TooLong
@@ -79,13 +79,13 @@ class PageController extends TwigController
         ]);
     }
 
-    public function add(Request $request, Response $response, array $args)
+    public function add(Request $request, Response $response, array $args): Response
     {
         $data = ParameterChecker::getInstance()->parseAddFormPreSelectionParameters($request);
         return $this->addResponse($response, $data);
     }
 
-    public function addForm(Request $request, Response $response, array $args)
+    public function addForm(Request $request, Response $response, array $args): Response
     {
         $check = ParameterChecker::getInstance()->parseAddFormParameters($request);
         $added = [];
@@ -104,7 +104,7 @@ class PageController extends TwigController
         return $this->addResponse($response, $check['data'], $added, $check['messages']);
     }
 
-    private function addResponse(Response $response, array $data, array $added = [], array $messages = [])
+    private function addResponse(Response $response, array $data, array $added = [], array $messages = []): Response
     {
         return $this->twig->render($response, 'pages/add.html.twig', [
             'title' => _('Gemeinde eintragen'),
@@ -116,7 +116,7 @@ class PageController extends TwigController
         ]);
     }
 
-    public function stats(Request $request, Response $response, array $args)
+    public function stats(Request $request, Response $response, array $args): Response
     {
         $db = Database::getInstance();
         return $this->twig->render($response, 'pages/stats.html.twig', [
@@ -133,7 +133,7 @@ class PageController extends TwigController
 
     public function details(Request $request, Response $response, array $args)
     {
-        $id = intval($args['id']);
+        $id = (int)$args['id'];
         if ($id > 0) {
             // Redirect for old URL.
             $entry = Database::getInstance()->getEntry($id, true);
@@ -164,7 +164,7 @@ class PageController extends TwigController
         ]);
     }
 
-    public function privacy(Request $request, Response $response, array $args)
+    public function privacy(Request $request, Response $response, array $args): Response
     {
         return $this->twig->render($response, 'pages/privacy.html.twig', [
             'title' => _('Datenschutzerklärung'),
@@ -172,16 +172,16 @@ class PageController extends TwigController
         ]);
     }
 
-    public function data(Request $request, Response $response, array $args)
+    public function data(Request $request, Response $response, array $args): Response
     {
         return $this->twig->render($response, 'pages/data.html.twig', [
             'title' => _('Offene Daten')
         ]);
     }
 
-    public function error(Request $request, Response $response, array $args)
+    public function error(Request $request, Response $response, array $args): Response
     {
-        if (substr($request->getRequestTarget(), 0, 3) == '/en') {
+        if (strpos($request->getRequestTarget(), '/en') === 0) {
             $this->setLanguage('en_US', $request);
         } else {
             $this->setLanguage('de_DE', $request);
@@ -195,13 +195,13 @@ class PageController extends TwigController
         ])->withStatus(404);
     }
 
-    public function opensearch(Request $request, Response $response, array $args)
+    public function opensearch(Request $request, Response $response, array $args): Response
     {
         return $this->twig->render($response, 'pages/opensearch.xml.twig')
                           ->withHeader('Content-Type', 'text/xml; charset=UTF-8');
     }
 
-    public function admin(Request $request, Response $response, array $args)
+    public function admin(Request $request, Response $response, array $args): Response
     {
         $this->setLanguage('de_DE', $request);
         $db = Database::getInstance();

--- a/src/Controllers/PageController.php
+++ b/src/Controllers/PageController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace KirchenImWeb\Controllers;
 
 use KirchenImWeb\Helpers\Configuration;

--- a/src/Controllers/TwigController.php
+++ b/src/Controllers/TwigController.php
@@ -38,7 +38,7 @@ class TwigController
 
         // Add I18n extension for Twig and init textdomain and set default language.
         $this->twig->addExtension(new Twig_Extensions_Extension_I18n());
-        $textdomain = "kirchen-im-web";
+        $textdomain = 'kirchen-im-web';
         bindtextdomain($textdomain, 'lang');
         bind_textdomain_codeset($textdomain, 'UTF-8');
         textdomain($textdomain);

--- a/src/Helpers/AbstractHelper.php
+++ b/src/Helpers/AbstractHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace KirchenImWeb\Helpers;
 
 /**
@@ -27,7 +28,7 @@ class AbstractHelper
     {
         static $instance = null;
         if (null === $instance) {
-            $instance = new static;
+            $instance = new static();
         }
         return $instance;
     }

--- a/src/Helpers/Configuration.php
+++ b/src/Helpers/Configuration.php
@@ -25,6 +25,8 @@ class Configuration extends AbstractHelper
 
     protected function __construct()
     {
+        parent::__construct();
+
         $this->countries = [
             'DE' => _('Deutschland'),
             'LI' => _('Liechtenstein'),

--- a/src/Helpers/Configuration.php
+++ b/src/Helpers/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace KirchenImWeb\Helpers;
 
 /**

--- a/src/Helpers/Database.php
+++ b/src/Helpers/Database.php
@@ -32,7 +32,7 @@ class Database extends AbstractHelper
         }
     }
 
-    public function getEntries()
+    public function getEntries(): array
     {
         $websites = Configuration::getInstance()->websites;
         $query = 'SELECT id, slug, lat, lon, name, street, postalCode, city, country, denomination, churches.type';
@@ -48,7 +48,7 @@ class Database extends AbstractHelper
         return $statement->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getFilteredEntries($filters, $websites, $compare = false)
+    public function getFilteredEntries($filters, $websites, $compare = false): array
     {
         // Query churches
         $query = 'SELECT id, slug, lat, lon, name, street, postalCode, city, country, denomination, churches.type';
@@ -67,48 +67,46 @@ class Database extends AbstractHelper
         // ... and apply the filters
         $conditions = [];
         if (isset($filters['ids']) && $filters['ids'] && count($filters['ids']) > 0) {
-            array_push($conditions, 'id IN (' . implode(', ', $filters['ids']) . ') ');
+            $conditions[] = 'id IN (' . implode(', ', $filters['ids']) . ') ';
         }
         if (isset($filters['parent']) && $filters['parent'] > 0) {
             $children = $this->getChildrenOfEntry(
                 $filters['parent'],
-                Database::getOption($filters, 'childrenRecursive')
+                self::getOption($filters, 'childrenRecursive')
             );
             $childrenIds = array_merge(
-                Database::getOption($filters, 'includeSelf') ? [$filters['parent']] : [],
-                Database::extractIds($children)
+                self::getOption($filters, 'includeSelf') ? [$filters['parent']] : [],
+                self::extractIds($children)
             );
-            array_push($conditions, 'id IN (' . implode(', ', $childrenIds) . ') ');
+            $conditions[] = 'id IN (' . implode(', ', $childrenIds) . ') ';
         }
-        if (isset($filters['name']) && $filters['name'] != '') {
-            array_push($conditions, 'name LIKE :name ');
+        if (isset($filters['name']) && $filters['name'] !== '') {
+            $conditions[] = 'name LIKE :name ';
         }
         if (isset($filters['postalCode']) && $filters['postalCode'] != 0) {
-            array_push($conditions, 'postalCode = :postalCode ');
+            $conditions[] = 'postalCode = :postalCode ';
         }
-        if (isset($filters['city']) && $filters['city'] != '') {
-            array_push($conditions, 'city LIKE :city ');
+        if (isset($filters['city']) && $filters['city'] !== '') {
+            $conditions[] = 'city LIKE :city ';
         }
-        if (isset($filters['country']) && $filters['country'] != '') {
-            array_push($conditions, 'country = :country ');
+        if (isset($filters['country']) && $filters['country'] !== '') {
+            $conditions[] = 'country = :country ';
         }
-        if (isset($filters['denomination']) && $filters['denomination'] != '') {
-            array_push($conditions, 'denomination = :denomination ');
+        if (isset($filters['denomination']) && $filters['denomination'] !== '') {
+            $conditions[] = 'denomination = :denomination ';
         }
-        if (isset($filters['type']) && $filters['type'] != '') {
-            array_push($conditions, 'churches.type = :ctype ');
+        if (isset($filters['type']) && $filters['type'] !== '') {
+            $conditions[] = 'churches.type = :ctype ';
         }
-        if (isset($filters['hasWebsiteType']) && $filters['hasWebsiteType'] != '') {
-            array_push($conditions, 'EXISTS (SELECT * FROM websites WHERE id = churchId AND type = :wtype) ');
+        if (isset($filters['hasWebsiteType']) && $filters['hasWebsiteType'] !== '') {
+            $conditions[] = 'EXISTS (SELECT * FROM websites WHERE id = churchId AND type = :wtype) ';
         }
         if ($compare) {
             // restrict to churches with at least one profile with followers set
             $compare_conditions = [];
             foreach (Configuration::getInstance()->networksToCompare as $websiteId => $websiteName) {
-                array_push(
-                    $compare_conditions,
-                    '(' . $websiteId . '.followers IS NOT NULL AND ' . $websiteId . '.followers > 0) '
-                );
+                $compare_conditions[] =
+                    '(' . $websiteId . '.followers IS NOT NULL AND ' . $websiteId . '.followers > 0) ';
             }
             if (sizeof($compare_conditions) > 0) {
                 $only_socialmedia_compare_condition = '';
@@ -117,7 +115,7 @@ class Database extends AbstractHelper
                 }
                 $only_socialmedia_compare_condition =
                     preg_replace('/ OR/', '(', $only_socialmedia_compare_condition, 1) . ')';
-                array_push($conditions, $only_socialmedia_compare_condition);
+                $conditions[] = $only_socialmedia_compare_condition;
             }
         }
 
@@ -134,27 +132,27 @@ class Database extends AbstractHelper
         }
 
         $statement = $this->connection->prepare($query);
-        if (isset($filters['name']) && $filters['name'] != '') {
+        if (isset($filters['name']) && $filters['name'] !== '') {
             $name = '%' . $filters['name'] . '%';
             $statement->bindParam(':name', $name);
         }
         if (isset($filters['postalCode']) && $filters['postalCode'] != 0) {
             $statement->bindParam(':postalCode', $filters['postalCode']);
         }
-        if (isset($filters['city']) && $filters['city'] != '') {
+        if (isset($filters['city']) && $filters['city'] !== '') {
             $city = '%' . $filters['city'] . '%';
             $statement->bindParam(':city', $city);
         }
-        if (isset($filters['country']) && $filters['country'] != '') {
+        if (isset($filters['country']) && $filters['country'] !== '') {
             $statement->bindParam(':country', $filters['country']);
         }
-        if (isset($filters['denomination']) && $filters['denomination'] != '') {
+        if (isset($filters['denomination']) && $filters['denomination'] !== '') {
             $statement->bindParam(':denomination', $filters['denomination']);
         }
-        if (isset($filters['type']) && $filters['type'] != '') {
+        if (isset($filters['type']) && $filters['type'] !== '') {
             $statement->bindParam(':ctype', $filters['type']);
         }
-        if (isset($filters['hasWebsiteType']) && $filters['hasWebsiteType'] != '') {
+        if (isset($filters['hasWebsiteType']) && $filters['hasWebsiteType'] !== '') {
             $statement->bindParam(':wtype', $filters['hasWebsiteType']);
         }
 
@@ -165,14 +163,14 @@ class Database extends AbstractHelper
 
     private static function getOption($filters, $name)
     {
-        return isset($filters['options'][$name]) ? $filters['options'][$name] : false;
+        return $filters['options'][$name] ?? false;
     }
 
     private static function extractIds($entries)
     {
         $ids = [];
         foreach ($entries as $entry) {
-            array_push($ids, $entry['id']);
+            $ids[] = $entry['id'];
             if (isset($entry['children'])) {
                 $ids = array_merge($ids, Database::extractIds($entry['children']));
             }
@@ -180,27 +178,25 @@ class Database extends AbstractHelper
         return $ids;
     }
 
-    public function getWebsitesWithMissingFollowers()
+    public function getWebsitesWithMissingFollowers(): array
     {
-        $statement = $this->connection->prepare('SELECT *
+        $statement = $this->connection->query('SELECT *
             FROM websites
             WHERE followersStatus = 0
             ORDER BY type, url');
-        $statement->execute();
         return $statement->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getErrorWebsitesByStatusCode()
+    public function getErrorWebsitesByStatusCode(): array
     {
-        $statement = $this->connection->prepare('SELECT *
+        $statement = $this->connection->query('SELECT *
             FROM websites
             WHERE statusCode != 200 AND notesUpdate < (NOW() - INTERVAL 90 DAY)
             ORDER BY url');
-        $statement->execute();
         return $statement->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getRecentlyAddedEntries()
+    public function getRecentlyAddedEntries(): array
     {
         $showWebsites = Configuration::getInstance()->preselectedWebsites;
 
@@ -218,13 +214,11 @@ class Database extends AbstractHelper
 
         $query .= ' ORDER BY churches.timestamp DESC, id DESC LIMIT 6';
 
-        $statement = $this->connection->prepare($query);
-        $statement->execute();
-
+        $statement = $this->connection->query($query);
         return $statement->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getParentEntries()
+    public function getParentEntries(): array
     {
         $statement = $this->connection->query('SELECT id, slug, name FROM churches
 			WHERE hasChildren = 1
@@ -234,7 +228,7 @@ class Database extends AbstractHelper
 
     public function getEntry($id, $childrenRecursive = false)
     {
-        $id = intval($id);
+        $id = (int)$id;
 
         // Query for the entry itself
         $statement = $this->connection->prepare('SELECT * FROM churches
@@ -257,14 +251,14 @@ class Database extends AbstractHelper
         // Query for the websites
         $statement = $this->connection->prepare('SELECT websiteId, url, type, followers FROM websites
             WHERE churchId = :id
-            ORDER BY type ASC');
+            ORDER BY type');
         $statement->bindParam(':id', $id);
         $statement->execute();
         $data['websites'] = $statement->fetchAll(PDO::FETCH_ASSOC);
 
         // Queries for the followers history of the social media entries.
         foreach ($data['websites'] as $key => $website) {
-            if (in_array($website['type'], array_keys(Configuration::getInstance()->networksToCompare))) {
+            if (array_key_exists($website['type'], Configuration::getInstance()->networksToCompare)) {
                 $data['websites'][$key]['followerHistory'] = $this->getFollowerHistory($website['websiteId']);
             }
             unset($data['websites'][$key]['websiteId']);
@@ -284,15 +278,15 @@ class Database extends AbstractHelper
         $statement->bindParam(':parentId', $parentId);
         $statement->execute();
         $parentData = $statement->fetch(PDO::FETCH_ASSOC);
-        array_push($parents, [
-            'id' => $parentId,
+        $parents[] = [
+            'id'   => $parentId,
             'slug' => $parentData['slug'],
             'name' => $parentData['name']
-        ]);
+        ];
         return $this->getParentsOfEntry($parentData['parentId'], $parents);
     }
 
-    private function getChildrenOfEntry($parentId, $recursive)
+    private function getChildrenOfEntry($parentId, $recursive): array
     {
         $statement = $this->connection->prepare('SELECT id, slug, name
             FROM churches
@@ -310,7 +304,7 @@ class Database extends AbstractHelper
         return $children;
     }
 
-    public function getAllChurchesWithLastUpdate()
+    public function getAllChurchesWithLastUpdate(): array
     {
         $statement = $this->connection->query('SELECT id, slug, IFNULL(lastFollowerUpdate, timestamp) AS lastUpdate
             FROM churches
@@ -322,8 +316,9 @@ class Database extends AbstractHelper
         return $statement->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getURLsForUpdate($networksToCompareList, int $limit = 10)
+    public function getURLsForUpdate(int $limit): array
     {
+        $networksToCompareList = $this->getNetworksToCompareList();
         $statement = $this->connection->prepare('SELECT websiteId, churchId, url, type, followers, followersLastUpdate
             FROM websites
             WHERE type IN (' . $networksToCompareList . ')
@@ -334,11 +329,12 @@ class Database extends AbstractHelper
         return $statement->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getWebsitesToCheck(int $limit = 25)
+    public function getWebsitesToCheck(int $limit): array
     {
+        $networksToCompareList = $this->getNetworksToCompareList();
         $statement = $this->connection->prepare('SELECT websiteId, url
             FROM websites
-            WHERE lastCheck IS NULL OR lastCheck <= CURDATE()
+            WHERE lastCheck IS NULL OR lastCheck <= CURDATE() AND type NOT IN (' . $networksToCompareList . ')
             ORDER BY lastCheck
             LIMIT :maxResults');
         $statement->bindParam(':maxResults', $limit, PDO::PARAM_INT);
@@ -346,7 +342,17 @@ class Database extends AbstractHelper
         return $statement->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function updateWebsiteCheck($websiteId, $statusCode, $redirectTarget)
+    private function getNetworksToCompareList(): string
+    {
+        $networksToCompare = Configuration::getInstance()->networksToCompare;
+        $networksToCompareAsStrings = [];
+        foreach ($networksToCompare as $type => $typeName) {
+            $networksToCompareAsStrings[] = "'" . $type . "'";
+        }
+        return implode(', ', $networksToCompareAsStrings);
+    }
+
+    public function updateWebsiteCheck($websiteId, $statusCode, $redirectTarget): bool
     {
         $statement = $this->connection->prepare('UPDATE websites
             SET statusCode = :statusCode,
@@ -359,7 +365,7 @@ class Database extends AbstractHelper
         return $statement->execute();
     }
 
-    public function updateFollowers($websiteId, $followers)
+    public function updateFollowers($websiteId, $followers): bool
     {
         if ($followers === false) {
             $statement = $this->connection->prepare('UPDATE websites
@@ -378,7 +384,7 @@ class Database extends AbstractHelper
         return $statement->execute();
     }
 
-    public function addFollowers($websiteId, $followers)
+    public function addFollowers($websiteId, $followers): bool
     {
         $statement = $this->connection->prepare('INSERT INTO followers 
 			    (websiteId, followers, date)
@@ -388,7 +394,7 @@ class Database extends AbstractHelper
         return $statement->execute();
     }
 
-    private function getFollowerHistory($websiteId)
+    private function getFollowerHistory($websiteId): array
     {
         $statement = $this->connection->prepare('SELECT followers, date FROM followers
 			WHERE websiteId = :websiteId');
@@ -404,7 +410,7 @@ class Database extends AbstractHelper
         return $statementTotal->fetch(PDO::FETCH_ASSOC);
     }
 
-    public function getStatsByCountry()
+    public function getStatsByCountry(): array
     {
         $queryByCountry = 'SELECT count(*) AS count, country as countryCode
             FROM churches
@@ -414,28 +420,28 @@ class Database extends AbstractHelper
         return $statementByCountry->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getStatsByDenomination()
+    public function getStatsByDenomination(): array
     {
         $queryByDenomination = 'SELECT count(*) AS count, denomination FROM churches GROUP BY denomination';
         $statementByDenomination = $this->connection->query($queryByDenomination);
         return $statementByDenomination->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getStatsByType()
+    public function getStatsByType(): array
     {
         $queryByType = 'SELECT count(*) AS count, type FROM churches GROUP BY type ORDER BY count DESC';
         $statementByType = $this->connection->query($queryByType);
         return $statementByType->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getStatsByWebsite()
+    public function getStatsByWebsite(): array
     {
         $queryByWebsite = 'SELECT count(*) AS count, type FROM websites GROUP BY type ORDER BY count DESC';
         $statementByWebsite = $this->connection->query($queryByWebsite);
         return $statementByWebsite->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function getStatsHTTPS()
+    public function getStatsHTTPS(): array
     {
         $queryByWebsiteHTTPS = 'SELECT w1.type, IFNULL(count, 0) as count, IFNULL(countHTTPS, 0) as countHTTPS  
             FROM (
@@ -506,10 +512,10 @@ class Database extends AbstractHelper
             $statement->execute();
         }
 
-        return $this->getEntry(intval($churchId));
+        return $this->getEntry((int)$churchId);
     }
 
-    private function createSlug($name)
+    private function createSlug($name): string
     {
         $name = mb_strtolower($name, 'UTF-8');
         $name = str_replace([' ', '/', '(', ')'], '-', $name);
@@ -532,7 +538,7 @@ class Database extends AbstractHelper
         return $slug;
     }
 
-    public function getIDForSlug($slug)
+    public function getIDForSlug(string $slug)
     {
         $statement = $this->connection->prepare('
 			SELECT id FROM churches
@@ -540,14 +546,13 @@ class Database extends AbstractHelper
         $statement->bindParam(':slug', $slug);
         $statement->execute();
         $result = $statement->fetch(PDO::FETCH_ASSOC);
-        return $result ? intval($result['id']) : false;
+        return $result ? (int)$result['id'] : false;
     }
 
-    public function getSettings()
+    public function getSettings(): array
     {
-        $statement = $this->connection->prepare('SELECT name, value
+        $statement = $this->connection->query('SELECT name, value
 			FROM settings');
-        $statement->execute();
         return $statement->fetchAll(PDO::FETCH_KEY_PAIR);
     }
 }

--- a/src/Helpers/Database.php
+++ b/src/Helpers/Database.php
@@ -322,8 +322,8 @@ class Database extends AbstractHelper
         $networksToCompareList = $this->getNetworksToCompareList();
         $statement = $this->connection->prepare('SELECT websiteId, churchId, url, type, followers, followersLastUpdate
             FROM websites
-            WHERE type IN (' . $networksToCompareList . ')
-            ORDER BY followersLastUpdate 
+            WHERE type IN (' . $networksToCompareList . ') AND followersStatus != 2
+            ORDER BY followersLastUpdate
             LIMIT :maxResults');
         $statement->bindParam(':maxResults', $limit, PDO::PARAM_INT);
         $statement->execute();
@@ -495,7 +495,7 @@ class Database extends AbstractHelper
         $churchId = $this->connection->lastInsertId();
 
         // Set parent id.
-        if ($data['parentId'] != 0) {
+        if ($data['parentId'] !== 0) {
             $statement = $this->connection->prepare('UPDATE churches SET parentId = :parentId
 				WHERE id = :id');
             $statement->bindParam(':parentId', $data['parentId'], PDO::PARAM_INT);

--- a/src/Helpers/Database.php
+++ b/src/Helpers/Database.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace KirchenImWeb\Helpers;
 
 use PDO;
@@ -22,7 +23,7 @@ class Database extends AbstractHelper
         ];
         try {
             $this->connection = new PDO(
-                'mysql:host='.DATABASE_HOSTNAME.';dbname='.DATABASE_NAME.';charset=utf8',
+                'mysql:host=' . DATABASE_HOSTNAME . ';dbname=' . DATABASE_NAME . ';charset=utf8',
                 DATABASE_USERNAME,
                 DATABASE_PASSWORD,
                 $options
@@ -37,7 +38,7 @@ class Database extends AbstractHelper
         $websites = Configuration::getInstance()->websites;
         $query = 'SELECT id, slug, lat, lon, name, street, postalCode, city, country, denomination, churches.type';
         foreach ($websites as $websiteId => $websiteName) {
-            $query .= ', ' .$websiteId . '.url AS ' . $websiteId;
+            $query .= ', ' . $websiteId . '.url AS ' . $websiteId;
         }
         $query .= ' FROM churches ';
         foreach ($websites as $websiteId => $websiteName) {
@@ -53,7 +54,7 @@ class Database extends AbstractHelper
         // Query churches
         $query = 'SELECT id, slug, lat, lon, name, street, postalCode, city, country, denomination, churches.type';
         foreach ($websites as $websiteId => $websiteName) {
-            $query .= ', ' .$websiteId . '.url AS ' . $websiteId . ', '
+            $query .= ', ' . $websiteId . '.url AS ' . $websiteId . ', '
                       . $websiteId . '.followers AS ' . $websiteId . '_followers';
         }
         $query .= ' FROM churches ';
@@ -202,7 +203,7 @@ class Database extends AbstractHelper
 
         $query = 'SELECT id, slug, name, postalCode, city, country, denomination, churches.type';
         foreach ($showWebsites as $websiteId => $websiteName) {
-            $query .= ', ' .$websiteId . '.url AS ' . $websiteId;
+            $query .= ', ' . $websiteId . '.url AS ' . $websiteId;
         }
         $query .= ' FROM churches ';
 

--- a/src/Helpers/Exporter.php
+++ b/src/Helpers/Exporter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace KirchenImWeb\Helpers;
 
 /**

--- a/src/Helpers/Exporter.php
+++ b/src/Helpers/Exporter.php
@@ -2,6 +2,8 @@
 
 namespace KirchenImWeb\Helpers;
 
+use RuntimeException;
+
 /**
  * Class Exporter
  *
@@ -13,10 +15,11 @@ class Exporter extends AbstractHelper
 
     public function __construct()
     {
+        parent::__construct();
         $this->dataDirectory = dirname(__FILE__, 3) . '/data';
     }
 
-    public function export()
+    public function export(): void
     {
         $this->checkDataDirectory();
         $entries = Database::getInstance()->getEntries();
@@ -24,17 +27,17 @@ class Exporter extends AbstractHelper
         $this->createCSV($entries, Configuration::getInstance()->websites);
     }
 
-    private function checkDataDirectory()
+    private function checkDataDirectory(): void
     {
-        if (!file_exists($this->dataDirectory) || !is_dir($this->dataDirectory)) {
-            mkdir($this->dataDirectory);
+        if (! file_exists($this->dataDirectory) && ! mkdir($this->dataDirectory) && ! is_dir($this->dataDirectory)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $this->dataDirectory));
         }
     }
 
-    private function createJSON(array $entries)
+    private function createJSON(array $entries): void
     {
         $filename = $this->dataDirectory . '/data-' . date('Y-m-d') . '.json';
-        $json = fopen($filename, 'w');
+        $json = fopen($filename, 'wb');
         $content = json_encode(
             $this->removeNullValues($entries),
             JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK
@@ -45,11 +48,11 @@ class Exporter extends AbstractHelper
         copy($filename, $this->dataDirectory . '/data.json');
     }
 
-    private function createCSV(array $entries, array $websites)
+    private function createCSV(array $entries, array $websites): void
     {
         $filename = $this->dataDirectory . '/data-' . date('Y-m-d') . '.csv';
 
-        $file = fopen($filename, 'w');
+        $file = fopen($filename, 'wb');
         $headline = 'id;lat;lon;Name;Straße;PLZ;Ort;Land;Konfession;Typ';
         foreach ($websites as $websiteId => $websiteName) {
             $headline .= ';' . $websiteName;
@@ -58,7 +61,7 @@ class Exporter extends AbstractHelper
 
         foreach ($entries as $row) {
             unset($row['slug']);
-            $data = implode(";", $row);
+            $data = implode(';', $row);
             fwrite($file, $data . "\n");
         }
         fclose($file);

--- a/src/Helpers/Mailer.php
+++ b/src/Helpers/Mailer.php
@@ -7,7 +7,7 @@ use PHPMailer\PHPMailer\PHPMailer;
 
 class Mailer extends AbstractHelper
 {
-    public function sendMail($subject, $bodyHTML, $bodyText = '')
+    public function sendMail($subject, $bodyHTML, $bodyText = ''): ?bool
     {
         $mail = new PHPMailer();
         $mail->isSMTP();
@@ -18,14 +18,13 @@ class Mailer extends AbstractHelper
         $mail->Username = MAIL_USERNAME;
         $mail->Password = MAIL_PASSWORD;
 
-        $mail->setFrom(MAIL_FROM);
-        $mail->addAddress(MAIL_TO);
-        $mail->CharSet = 'UTF-8';
-        $mail->Subject = $subject;
-        $mail->msgHTML($bodyHTML);
-        $mail->AltBody = $bodyText;
-
         try {
+            $mail->setFrom(MAIL_FROM);
+            $mail->addAddress(MAIL_TO);
+            $mail->CharSet = 'UTF-8';
+            $mail->Subject = $subject;
+            $mail->msgHTML($bodyHTML);
+            $mail->AltBody = $bodyText;
             return $mail->send();
         } catch (Exception $exception) {
             return false;

--- a/src/Helpers/ParameterChecker.php
+++ b/src/Helpers/ParameterChecker.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace KirchenImWeb\Helpers;
 
 use Exception;
@@ -17,8 +18,8 @@ class ParameterChecker extends AbstractHelper
     {
         $data = $request->getQueryParams();
         $filters = [];
-        $filters['ids'] = isset($data['ids']) ? $this->toIntArray($data['ids']): [];
-        $filters['parent'] = isset($data['parent']) ? intval($data['parent']): 0;
+        $filters['ids'] = isset($data['ids']) ? $this->toIntArray($data['ids']) : [];
+        $filters['parent'] = isset($data['parent']) ? intval($data['parent']) : 0;
         $filters['name'] = isset($data['name']) ? trim($data['name']) : '';
         $filters['postalCode'] =
             isset($_GET['postalCode']) && intval($_GET['postalCode']) > 0 ? $_GET['postalCode'] : '';
@@ -61,8 +62,10 @@ class ParameterChecker extends AbstractHelper
         $data = $request->getQueryParams();
         $websites = [];
         foreach (Configuration::getInstance()->websites as $websiteId => $websiteName) {
-            if ((isset($data['hasWebsiteType']) && $data['hasWebsiteType'] == $websiteId)
-                || (isset($data[$websiteId]) && $data[$websiteId] == 'show') ) {
+            if (
+                (isset($data['hasWebsiteType']) && $data['hasWebsiteType'] == $websiteId)
+                || (isset($data[$websiteId]) && $data[$websiteId] == 'show')
+            ) {
                 $websites[$websiteId] = $websiteName;
             }
         }

--- a/src/Updaters/LinkCheck.php
+++ b/src/Updaters/LinkCheck.php
@@ -12,7 +12,7 @@ class LinkCheck
     private $httpStatusCode;
     private $redirectTarget;
 
-    const USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0';
+    public const USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:65.0) Gecko/20100101 Firefox/65.0';
 
     /**
      * Checks the availability of the website with the given URL.

--- a/src/Updaters/LinkCheck.php
+++ b/src/Updaters/LinkCheck.php
@@ -35,7 +35,7 @@ class LinkCheck
      * @param string $url the URL to check
      * @param bool $useHead true for a HEAD request, false for a GET request
      */
-    private function check(string $url, $useHead = true)
+    private function check(string $url, $useHead = true): void
     {
         $handle = curl_init($url);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
@@ -53,7 +53,7 @@ class LinkCheck
      *
      * @return int the status code
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->httpStatusCode;
     }
@@ -63,7 +63,7 @@ class LinkCheck
      *
      * @return string the target URL
      */
-    public function getRedirectTarget()
+    public function getRedirectTarget(): string
     {
         return $this->redirectTarget;
     }

--- a/src/Updaters/LinkCheckUpdater.php
+++ b/src/Updaters/LinkCheckUpdater.php
@@ -11,9 +11,9 @@ use KirchenImWeb\Helpers\Database;
  */
 class LinkCheckUpdater
 {
-    public function check()
+    public function check(): void
     {
-        $websites = Database::getInstance()->getWebsitesToCheck();
+        $websites = Database::getInstance()->getWebsitesToCheck(10);
         foreach ($websites as $website) {
             $l = new LinkCheck($website['url']);
             Database::getInstance()->updateWebsiteCheck(

--- a/src/Updaters/SocialMediaUpdater.php
+++ b/src/Updaters/SocialMediaUpdater.php
@@ -1,6 +1,8 @@
 <?php
 namespace KirchenImWeb\Updaters;
 
+use DOMDocument;
+use InstagramScraper\Instagram;
 use KirchenImWeb\Helpers\AbstractHelper;
 use KirchenImWeb\Helpers\Configuration;
 use KirchenImWeb\Helpers\Database;
@@ -15,14 +17,13 @@ use TwitterAPIExchange;
 class SocialMediaUpdater extends AbstractHelper
 {
 
-    public function cron()
+    public function cron(): array
     {
         // Create list of networks to compare (escaped, comma-separated)
         $networksToCompare = Configuration::getInstance()->networksToCompare;
-        $networksToCompare = array_diff($networksToCompare, ['facebook' => 'Facebook']);
         $networksToCompareAsStrings = [];
         foreach ($networksToCompare as $type => $typeName) {
-            array_push($networksToCompareAsStrings, "'" . $type . "'");
+            $networksToCompareAsStrings[] = "'" . $type . "'";
         }
         $networksToCompareList = implode(', ', $networksToCompareAsStrings);
 
@@ -31,7 +32,7 @@ class SocialMediaUpdater extends AbstractHelper
         $urls = Database::getInstance()->getURLsForUpdate($networksToCompareList);
         $results = [];
         foreach ($urls as $row) {
-            array_push($results, $this->update($row));
+            $results[] = $this->update($row);
         }
         $duration = (microtime(true) - $time);
 
@@ -42,16 +43,16 @@ class SocialMediaUpdater extends AbstractHelper
         ];
     }
 
-    private function update($row)
+    private function update(array $row): array
     {
-        $websiteId = intval($row['websiteId']);
+        $websiteId = (int)$row['websiteId'];
         $url = $row['url'];
         $followersNew = $this->getFollowers($row['type'], $url);
         $data = [
-            'churchId' => intval($row['churchId']),
+            'churchId' => (int)$row['churchId'],
             'url' => $url,
             'followersNew' => $followersNew,
-            'followersOld' => is_null($row['followers']) ? null : intval($row['followers'])
+            'followersOld' => $row['followers'] === null ? null : (int)$row['followers']
         ];
 
         if ($followersNew >= 0) {
@@ -74,7 +75,7 @@ class SocialMediaUpdater extends AbstractHelper
      *
      * @return int|bool the follower count; false in case of errors.
      */
-    private function getFollowers($network, $url)
+    private function getFollowers(string $network, string $url)
     {
         switch ($network) {
             case 'facebook':
@@ -97,39 +98,48 @@ class SocialMediaUpdater extends AbstractHelper
      *
      * @return int|bool the number of likes, or false on failure
      */
-    private function getFacebookLikes($url)
+    private function getFacebookLikes(string $url)
     {
-        try {
-            $id = substr($url, 25); // 25 = strlen('https://www.facebook.com/')
-            if (SocialMediaUpdater::startsWith($id, 'groups/')) {
-                return false;
-            }
-            if (SocialMediaUpdater::startsWith($id, 'pages/')) {
-                $temp = explode('/', $id);
-                $id = end($temp);
-            }
+        $handle = curl_init($url);
+        curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handle, CURLOPT_HEADER, true);
+        curl_setopt($handle, CURLOPT_USERAGENT, LinkCheck::USER_AGENT);
+        $htmlCode = curl_exec($handle);
 
-            $json_url ='https://graph.facebook.com/' . $id .
-                       '?access_token='.FACEBOOK_API_ID.'|'.FACEBOOK_API_SECRET.'&fields=fan_count';
-            $json = @file_get_contents($json_url);
-            if (!$json) {
-                $temp = explode('-', $id);
-                $id = str_replace('/', '', end($temp));
-                $json_url ='https://graph.facebook.com/' . $id .
-                           '?access_token='.FACEBOOK_API_ID.'|'.FACEBOOK_API_SECRET.'&fields=fan_count';
-                $json = @file_get_contents($json_url);
-            }
-
-            if ($json) {
-                $json = json_decode($json);
-                if (isset($json->fan_count)) {
-                    return $json->fan_count;
+        if ($htmlCode) {
+            $metaDescription = $this->getMetaDescription($htmlCode);
+            if ($metaDescription) {
+                preg_match('/Gefällt (?P<likes>\d+(.\d+)*) Mal/mu', $metaDescription, $match);
+                if (isset($match['likes'])) {
+                    $i = (int)str_replace('.', '', $match['likes']);
+                    if ($i > 0) {
+                        return $i;
+                    }
                 }
             }
-            return false;
-        } catch (Exception $e) {
-            return false;
         }
+        return false;
+    }
+
+    /**
+     * Extracts the meta description from the given HTML code.
+     *
+     * @param string $html the HTML.
+     *
+     * @return bool|string the meta description, or false on failure
+     */
+    private function getMetaDescription(string $html)
+    {
+        libxml_use_internal_errors(true);
+        $doc = new DOMDocument();
+        $doc->loadHTML($html);
+        foreach ($doc->getElementsByTagName('meta') as $node) {
+            /** @var $node \DOMNode */
+            if ('description' === strtolower($node->getAttribute('name'))) {
+                return $node->getAttribute('content');
+            }
+        }
+        return false;
     }
 
     /**
@@ -139,11 +149,11 @@ class SocialMediaUpdater extends AbstractHelper
      *
      * @return int|bool the number of +1s, or false on failure
      */
-    private function getInstagramFollowers($url)
+    private function getInstagramFollowers(string $url)
     {
         try {
             $name = str_replace('/', '', substr($url, 25));
-            $instagram = new \InstagramScraper\Instagram();
+            $instagram = new Instagram();
             $account = $instagram->getAccount($name);
             return $account->getFollowedByCount();
         } catch (Exception $e) {
@@ -158,7 +168,7 @@ class SocialMediaUpdater extends AbstractHelper
      *
      * @return int|bool the number of subscribers, or false on failure
      */
-    private function getTwitterFollower($url)
+    private function getTwitterFollower(string $url)
     {
         try {
             $name = substr($url, 20);
@@ -172,9 +182,9 @@ class SocialMediaUpdater extends AbstractHelper
             $json = $twitterAPI->setGetfield('?screen_name=' . $name)
                                ->buildOauth('https://api.twitter.com/1.1/users/show.json', 'GET')
                                ->performRequest();
-            $json = json_decode($json);
+            $json = json_decode($json, false);
             if (isset($json->followers_count)) {
-                return intval($json->followers_count);
+                return (int)$json->followers_count;
             }
             return false;
         } catch (Exception $e) {
@@ -189,12 +199,12 @@ class SocialMediaUpdater extends AbstractHelper
      *
      * @return int|bool the number of subscribers, or false on failure
      */
-    private function getYoutubeSubscribers($url)
+    private function getYoutubeSubscribers(string $url)
     {
         try {
             $username = substr($url, 24);
             $channelId = false;
-            if (SocialMediaUpdater::startsWith($username, 'channel/')) {
+            if (self::startsWith($username, 'channel/')) {
                 $temp = explode('/', $username);
                 $channelId = end($temp);
             } else {
@@ -202,7 +212,7 @@ class SocialMediaUpdater extends AbstractHelper
                             . '&type=channel&key=' . GOOGLE_API_KEY;
                 $json = @file_get_contents($json_url);
                 if ($json) {
-                    $json = json_decode($json);
+                    $json = json_decode($json, false);
                     if (isset($json->items[0]->id->channelId)) {
                         $channelId = $json->items[0]->id->channelId;
                     }
@@ -214,9 +224,9 @@ class SocialMediaUpdater extends AbstractHelper
                             . '&key=' . GOOGLE_API_KEY;
                 $json = @file_get_contents($json_url);
                 if ($json) {
-                    $json = json_decode($json);
+                    $json = json_decode($json, false);
                     if (isset($json->items[0]->statistics->subscriberCount)) {
-                        return intval($json->items[0]->statistics->subscriberCount);
+                        return (int)$json->items[0]->statistics->subscriberCount;
                     }
                 }
             }
@@ -234,9 +244,9 @@ class SocialMediaUpdater extends AbstractHelper
      * @param string $needle the needle
      * @return boolean true if and only if the haystack starts with needle
      */
-    private static function startsWith($haystack, $needle)
+    private static function startsWith($haystack, $needle): bool
     {
         // search backwards starting from haystack length characters from the end
-        return $needle === "" || strrpos($haystack, $needle, -strlen($haystack)) !== false;
+        return $needle === '' || strrpos($haystack, $needle, -strlen($haystack)) !== false;
     }
 }

--- a/src/Updaters/SocialMediaUpdater.php
+++ b/src/Updaters/SocialMediaUpdater.php
@@ -3,7 +3,6 @@ namespace KirchenImWeb\Updaters;
 
 use DOMDocument;
 use InstagramScraper\Instagram;
-use KirchenImWeb\Helpers\AbstractHelper;
 use KirchenImWeb\Helpers\Configuration;
 use KirchenImWeb\Helpers\Database;
 use Exception;
@@ -12,24 +11,16 @@ use TwitterAPIExchange;
 /**
  * Class SocialMediaUpdater
  *
- * @package KirchenImWeb\Helpers
+ * @package KirchenImWeb\Updaters
  */
-class SocialMediaUpdater extends AbstractHelper
+class SocialMediaUpdater
 {
 
     public function cron(): array
     {
-        // Create list of networks to compare (escaped, comma-separated)
-        $networksToCompare = Configuration::getInstance()->networksToCompare;
-        $networksToCompareAsStrings = [];
-        foreach ($networksToCompare as $type => $typeName) {
-            $networksToCompareAsStrings[] = "'" . $type . "'";
-        }
-        $networksToCompareList = implode(', ', $networksToCompareAsStrings);
-
         // Start update and measure time.
         $time = microtime(true);
-        $urls = Database::getInstance()->getURLsForUpdate($networksToCompareList);
+        $urls = Database::getInstance()->getURLsForUpdate(10);
         $results = [];
         foreach ($urls as $row) {
             $results[] = $this->update($row);
@@ -38,7 +29,7 @@ class SocialMediaUpdater extends AbstractHelper
 
         return [
             'updatedEntries' => $results,
-            'included' => $networksToCompare,
+            'included' => Configuration::getInstance()->networksToCompare,
             'duration' => $duration
         ];
     }

--- a/src/Updaters/SocialMediaUpdater.php
+++ b/src/Updaters/SocialMediaUpdater.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace KirchenImWeb\Updaters;
 
 use DOMDocument;
@@ -46,7 +47,7 @@ class SocialMediaUpdater
             'followersOld' => $row['followers'] === null ? null : (int)$row['followers']
         ];
 
-        if ($followersNew >= 0) {
+        if ($followersNew && $followersNew > 0) {
             // Update follower number and the timestamp.
             Database::getInstance()->updateFollowers($websiteId, $followersNew);
             Database::getInstance()->addFollowers($websiteId, $followersNew);
@@ -97,7 +98,7 @@ class SocialMediaUpdater
         curl_setopt($handle, CURLOPT_USERAGENT, LinkCheck::USER_AGENT);
         $htmlCode = curl_exec($handle);
 
-        if ($htmlCode) {
+        if (curl_getinfo($handle, CURLINFO_RESPONSE_CODE) === 200 && $htmlCode) {
             $metaDescription = $this->getMetaDescription($htmlCode);
             if ($metaDescription) {
                 preg_match('/Gefällt (?P<likes>\d+(.\d+)*) Mal/mu', $metaDescription, $match);


### PR DESCRIPTION
- Fixes #27 with a workaround
- Fixes #34 via excluding accounts with `followerStatus = 2` (accounts need to marked with this status manually)